### PR TITLE
Release 3.8.10

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1161,16 +1161,6 @@ if module == "filterData":
             else:
                 break
         
-        hidden_values = set()
-        for row in values:
-            if len(row) > col_index:
-                cell = row[col_index]
-            else:
-                cell = ""
-            
-            if valor_filtro != cell:
-                hidden_values.add(cell)
-        
         ranges = {
             "sheetId": sheet_id,
             'startRowIndex': first_row
@@ -1182,7 +1172,14 @@ if module == "filterData":
                 'filterSpecs': [{
                     'columnIndex': col_index,
                     'filterCriteria': {
-                        'hiddenValues': list(hidden_values)
+                        'condition': {
+                            'type': 'TEXT_EQ',
+                            'values': [
+                                {
+                                    'userEnteredValue': valor_filtro
+                                }
+                            ]
+                        }
                     }
                 }]
             }

--- a/__init__.py
+++ b/__init__.py
@@ -1200,7 +1200,7 @@ if module == "filterCells":
     res = GetParams("res")
     range = GetParams("range_")
     row_info = GetParams("row_info")
-    
+    dont_show_header = GetParams("no_header")
     try:
         service = discovery.build('sheets', 'v4', credentials=mod_gss_session[session])
         
@@ -1215,45 +1215,80 @@ if module == "filterCells":
                 if not 'sheet_id' in locals():
                     raise Exception("Sheet could't be found...")
                 
-                filter_start = element["basicFilter"]["range"]["startRowIndex"]
+                filter_start = element["basicFilter"]["range"]["startRowIndex"] + 1
+                filter_end = element["basicFilter"]["range"]["endRowIndex"]
                 
         data = service.spreadsheets().get(spreadsheetId=ss_id, fields="sheets(data(rowMetadata(hiddenByFilter)),properties/sheetId)").execute()
 
         #column_filter = get_existing_basic_filters(ss_id, service)
-        list_hidden_rows = []
+        list_hidden_rows = set()
         for column in data['sheets']:
             if column['properties']['sheetId'] == sheet_id:
                 for index, item in enumerate(column['data'][0]['rowMetadata']):
                     if bool(item):
-                        list_hidden_rows.append(index)
+                        list_hidden_rows.add(index)
        
-        # It makes sure that always start from the first row of the filter, so the row index vs hidden rows can be done
-        range_first_row = range[1]
+        #Transforms the range from a String into a List and then gets the first and last row of the range
+        range_start_and_end = [item for item in range.split(":")]
+        range_start_and_end_numbers = list(map(lambda x: x[1:], range_start_and_end))
+        start_row = int(range_start_and_end_numbers[0])
+        end_row = int(range_start_and_end_numbers[1])
         
-        if range_first_row != filter_start:
-            tmp = list(range)
-            tmp[1] = filter_start + 1
-            
-            range = "".join(str(x) for x in tmp)
-            
-            
+        if start_row > filter_end:
+            raise Exception("Selected range starts after filtered range ended")
+
+        if start_row + end_row -1 < filter_start:
+            raise Exception("Selected range ends before filtered range starts")
+
+        tmp = range_start_and_end_numbers
+        if dont_show_header is None:
+
+            if start_row <= filter_start: #Starts from the filter
+                tmp[0] = filter_start
+
+            elif start_row > filter_start: #Starts from the filter, but hides the rows between it and the start of the given range.
+                diff = start_row - filter_start
+                while diff > 1:
+                    index = start_row-diff
+                    list_hidden_rows.add(index)
+                    diff -= 1
+                
+                tmp[0] = filter_start
+                
+            range = f"{range_start_and_end[0][0]}{tmp[0]}:{range_start_and_end[1][0]}{tmp[1]}"
+            start_row = filter_start
+
+        elif start_row <= filter_start: #Starts from the row after the filter
+            tmp[0] = filter_start + 1
+            range = f"{range_start_and_end[0][0]}{tmp[0]}:{range_start_and_end[1][0]}{tmp[1]}"
+            start_row = filter_start + 1
+
+
         range_ = sheet + "!" + range
         request = service.spreadsheets().values().get(spreadsheetId=ss_id, range=range_)
         response = request.execute()
-        value = response["values"]
+        value = response.get("values", [])
+        
+        if value == []:
+            raise Exception("Selected range is empty")
         
         final_cells = []
         final_cells_row = {}
         for row_index, item in enumerate(value):
-            row_index = (row_index + filter_start)
-            if row_info and eval(row_info) == True:
+            row_index = (row_index + start_row - 1)
+            if row_index >= filter_end:
+                break
+
+            elif row_info and eval(row_info) == True:
                 if row_index not in list_hidden_rows:
                     final_cells_row[row_index+1] = item   
                 SetVar(res, final_cells_row)
+
             else:
                 if row_index not in list_hidden_rows:
                     final_cells.append(item)                      
                 SetVar(res, final_cells)
+
     except Exception as e:
         traceback.print_exc()
         PrintException()
@@ -1332,3 +1367,4 @@ if module == "TextToColumns":
         SetVar(result, False)
         PrintException()
         raise e
+    

--- a/__init__.py
+++ b/__init__.py
@@ -1154,32 +1154,40 @@ if module == "filterData":
         
         # It checks where the table that is going to be filtered starts and ends 
         first_row = 0
-        values = req["values"]
+        values = req.get("values", [])
         for cell in values:
             if cell == []:
                 first_row += 1
             else:
                 break
-        last_row = len(req['values'])
+        
+        hidden_values = set()
+        for row in values:
+            if len(row) > col_index:
+                cell = row[col_index]
+            else:
+                cell = ""
+            
+            if valor_filtro != cell:
+                hidden_values.add(cell)
         
         ranges = {
             "sheetId": sheet_id,
-            'startRowIndex': first_row,
-            'endRowIndex': last_row,
-            'startColumnIndex': col_index,
-            'endColumnIndex': col_index + 1,
+            'startRowIndex': first_row
         }
         
-        hidden_values = []
-        for row in values:
-            # It appends a blank space to the list so the row is recognized as one in the following "for"
-            if row == []:
-                row.append("")
-            for cell in row:
-                if valor_filtro != cell:
-                    hidden_values.append(cell)
-        
-        filters = create_filter_structure(ranges, hidden_values, sheet_id)
+        filters = {
+            sheet_id: {
+                'range': ranges,
+                'filterSpecs': [{
+                    'columnIndex': col_index,
+                    'filterCriteria': {
+                        'hiddenValues': list(hidden_values)
+                    }
+                }]
+            }
+        }
+
         apply_filters(ss_id, filters, service)
     except Exception as e:
         traceback.print_exc()

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pr": "Este módulo permite que você leia, escreva e atualize as planilhas do Google. Você pode adicionar, excluir, duplicar ou até ocultar planilhas; filtrar dados; adicionar ou excluir linhas e colunas; modifique o formato das células, copie/recorte e cole-as; e mais."
   },
   "disclaimer": "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "license": "MIT",
   "homepage": "http://rocketbot.com",
   "linux": true,
@@ -2457,6 +2457,21 @@
               "pr": "Você obterá um dicionário onde a Key será o número da linha."
             },
             "id": "row_info",
+            "css": "col-md-6"
+          },
+          {
+            "type": "checkbox",
+            "placeholder": {
+              "es": "",
+              "en": "",
+              "pr": ""
+            },
+            "title": {
+              "es": "No mostrar encabezado:",
+              "en": "Do not show header:",
+              "pr": "Não mostrar cabeçalho:"
+            },
+            "id": "no_header",
             "css": "col-md-6"
           },
           {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pr": "Este módulo permite que você leia, escreva e atualize as planilhas do Google. Você pode adicionar, excluir, duplicar ou até ocultar planilhas; filtrar dados; adicionar ou excluir linhas e colunas; modifique o formato das células, copie/recorte e cole-as; e mais."
   },
   "disclaimer": "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.",
-  "version": "3.8.9",
+  "version": "3.8.10",
   "license": "MIT",
   "homepage": "http://rocketbot.com",
   "linux": true,

--- a/package.json
+++ b/package.json
@@ -2492,7 +2492,8 @@
               "pr": "Nome da variável sem {}"
             },
             "id": "res",
-            "css": "col-md-4"
+            "css": "col-md-4",
+            "remove_vars": true
           },
           {
             "type": "input",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pr": "Este módulo permite que você leia, escreva e atualize as planilhas do Google. Você pode adicionar, excluir, duplicar ou até ocultar planilhas; filtrar dados; adicionar ou excluir linhas e colunas; modifique o formato das células, copie/recorte e cole-as; e mais."
   },
   "disclaimer": "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.",
-  "version": "3.8.7",
+  "version": "3.8.8",
   "license": "MIT",
   "homepage": "http://rocketbot.com",
   "linux": true,


### PR DESCRIPTION
Fix:
- Filter data: Command sometimes fails to filter sheet properly, resulting in visible data. Corrective action taken.
- Get Filtered Cells: The command always returned cells starting from the filter header, ignoring the user-specified range. This issue has been fixed, and now it has a checkbox so that the user may choose whether to get the header or not. Additionally, it now throws exceptions in cases that were overlooked.